### PR TITLE
Add NTP time sync on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The project allows you to start and stop feeding timers and records the data dir
 - Displays the active child and current time on a small I2C LCD
 - Start and stop feeding timers with button presses
 - Select feeding type and method using a rotary encoder
+- Syncs the clock from `time.microsoft.com` on boot
 
 ## Hardware
 
@@ -26,7 +27,7 @@ These defaults can be changed by editing `hardware.py`.
 1. Install MicroPython on your board and copy the files from this repository (`main.py`, `api.py`, `hardware.py` and `secrets.json`).
 2. Edit `secrets.json` with your Wi‑Fi credentials and Baby Buddy API token.
 3. Ensure the libraries `urequests`, `machine_i2c_lcd` and `rotary_irq` are available on the device.
-4. Reset or power up the board. Once Wi‑Fi connects, the device will display the current time and is ready to log feedings.
+4. Reset or power up the board. After connecting to Wi‑Fi, the device synchronizes the clock using `time.microsoft.com` and then displays the current time ready for logging.
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 import network
 import utime
 import ujson as json
+import ntptime
 from hardware import LCDDisplay, ButtonArray, RotaryEncoder
 from api import BabyBuddyAPI
 
@@ -22,6 +23,21 @@ def connect_wifi(ssid, password, lcd):
     lcd.show("WiFi Error", "")
     utime.sleep(2)
     return False
+
+# --- Time Synchronization ---
+def sync_time(lcd, server="time.microsoft.com"):
+    """Synchronize RTC using NTP."""
+    try:
+        lcd.show("Syncing time", server)
+        ntptime.host = server
+        ntptime.settime()
+        lcd.clear()
+        return True
+    except Exception as e:
+        lcd.show("Time sync err", str(e)[:16])
+        utime.sleep(2)
+        lcd.clear()
+        return False
 
 # --- Feeding types/methods for selection ---
 FEED_TYPES = [
@@ -83,6 +99,9 @@ def main():
     if not connect_wifi(wifi["ssid"], wifi["password"], lcd):
         while True:
             utime.sleep(1)
+
+    # --- Sync time via NTP ---
+    sync_time(lcd)
 
     # --- Init API now that WiFi is up ---
     api = BabyBuddyAPI("secrets.json")


### PR DESCRIPTION
## Summary
- sync device clock from time.microsoft.com after Wi-Fi connection
- document time sync in features and setup steps

## Testing
- `python -m py_compile main.py api.py hardware.py`


------
https://chatgpt.com/codex/tasks/task_e_6844a4ddde9c832c806e6caa49b6e505