### PR TITLE
Fix false button press detection

### DIFF
--- a/hardware.py
+++ b/hardware.py
@@ -35,7 +35,9 @@ class LCDDisplay:
 class ButtonArray:
     def __init__(self, pins=(5,6,7,8,9,10,11,12), debounce_ms=40):
         self.pins = [Pin(p, Pin.IN, Pin.PULL_DOWN) for p in pins]
-        self.last_state = [1] * len(self.pins)
+        # Read the current state of each pin so that a press isn't
+        # falsely detected on boot. 0 means unpressed with pull-down.
+        self.last_state = [btn.value() for btn in self.pins]
         self.debounce = debounce_ms
         self.last_press_time = [0] * len(self.pins)
 


### PR DESCRIPTION
## Summary
- avoid detecting all buttons as pressed on boot by reading pin states during initialization

## Testing
- `python3 -m py_compile hardware.py main.py api.py`


------
https://chatgpt.com/codex/tasks/task_e_6844aa1d06c4832cb37298c5d570eb92