### PR TITLE
Fix timer stop logic

### DIFF
--- a/api.py
+++ b/api.py
@@ -107,10 +107,21 @@ class BabyBuddyAPI:
             payload.update(data)
         return self.post("timers", payload)
 
-    def stop_timer(self, timer_id, data=None):
-        """Stop timer by posting to timer endpoint with end timestamp."""
+    def finish_timer(self, activity_name, timer_id, data=None):
+        """Finalize a running timer by creating the corresponding entry."""
+        endpoint_map = {
+            "feeding": "feedings",
+            "sleep": "sleep",
+            "tummy time": "tummy-times",
+            "pumping": "pumping",
+        }
+        endpoint = endpoint_map.get(activity_name)
+        if not endpoint:
+            print(f"No endpoint for activity '{activity_name}'")
+            return None
         payload = data or {}
-        return self.post(f"timers/{timer_id}/stop", payload)
+        payload["timer"] = timer_id
+        return self.post(endpoint, payload)
 
     # --- Feeding Example ---
 
@@ -124,7 +135,7 @@ class BabyBuddyAPI:
     def stop_feeding(self, timer_id, feed_type, method):
         """Stop feeding timer with details."""
         payload = {"type": feed_type, "method": method}
-        return self.stop_timer(timer_id, payload)
+        return self.finish_timer("feeding", timer_id, payload)
 
     # --- Additional Logging Helpers ---
 

--- a/main.py
+++ b/main.py
@@ -175,7 +175,7 @@ def main():
                 # Select type
                 feed_type = select_from_list(lcd, "Feed Type?", FEED_TYPES, encoder)
                 feed_method = select_from_list(lcd, "Feed Method?", FEED_METHODS, encoder)
-                res = api.stop_timer(feeding_timer_id, data={"type": feed_type, "method": feed_method})
+                res = api.finish_timer("feeding", feeding_timer_id, data={"type": feed_type, "method": feed_method})
                 if res:
                     lcd.show("Logged!", feed_type + "/" + feed_method)
                 else:
@@ -196,7 +196,7 @@ def main():
                     lcd.show("Error: Timer", "")
                     utime.sleep(2)
             else:
-                res = api.stop_timer(sleep_timer_id)
+                res = api.finish_timer("sleep", sleep_timer_id)
                 if res:
                     lcd.show("Sleep Logged", "")
                 else:
@@ -227,7 +227,7 @@ def main():
                     lcd.show("Error: Timer", "")
                     utime.sleep(2)
             else:
-                res = api.stop_timer(tummy_timer_id)
+                res = api.finish_timer("tummy time", tummy_timer_id)
                 if res:
                     lcd.show("Tummy Logged", "")
                 else:
@@ -264,7 +264,7 @@ def main():
                     lcd.show("Error: Timer", "")
                     utime.sleep(2)
             else:
-                res = api.stop_timer(pumping_timer_id)
+                res = api.finish_timer("pumping", pumping_timer_id)
                 if res:
                     lcd.show("Pump Logged", "")
                 else:


### PR DESCRIPTION
## Summary
- implement finish_timer to log entries using the correct endpoints
- update main loop to call `finish_timer` for all activities

## Testing
- `python -m py_compile api.py main.py hardware.py`

------
https://chatgpt.com/codex/tasks/task_e_6844ad043330832c9dcafd935dc67a3f